### PR TITLE
Geode placement overhaul

### DIFF
--- a/src/main/java/com/github/thedeathlycow/moregeodes/features/ModFeatures.java
+++ b/src/main/java/com/github/thedeathlycow/moregeodes/features/ModFeatures.java
@@ -30,6 +30,15 @@ public class ModFeatures {
                 )
                 .add(
                         ModificationPhase.ADDITIONS,
+                        BiomeSelectors.tag(ModBiomeTags.HAS_EXTRA_EMERALD_GEODES),
+                        modifier(
+                                ModPlacedFeatures.EMERALD_GEODE_EXTRA,
+                                GenerationStep.Feature.UNDERGROUND_DECORATION,
+                                MoreGeodes.CONFIG.generateEmeraldGeodes()
+                        )
+                )
+                .add(
+                        ModificationPhase.ADDITIONS,
                         BiomeSelectors.tag(ModBiomeTags.HAS_QUARTZ_GEODE),
                         modifier(
                                 ModPlacedFeatures.QUARTZ_GEODE,
@@ -60,6 +69,15 @@ public class ModFeatures {
                         BiomeSelectors.tag(ModBiomeTags.HAS_LAPIS_GEODE),
                         modifier(
                                 ModPlacedFeatures.LAPIS_GEODE,
+                                GenerationStep.Feature.UNDERGROUND_DECORATION,
+                                MoreGeodes.CONFIG.generateLapisGeodes()
+                        )
+                )
+                .add(
+                        ModificationPhase.ADDITIONS,
+                        BiomeSelectors.tag(ModBiomeTags.HAS_EXTRA_LAPIS_GEODES),
+                        modifier(
+                                ModPlacedFeatures.LAPIS_GEODE_EXTRA,
                                 GenerationStep.Feature.UNDERGROUND_DECORATION,
                                 MoreGeodes.CONFIG.generateLapisGeodes()
                         )

--- a/src/main/java/com/github/thedeathlycow/moregeodes/features/ModPlacedFeatures.java
+++ b/src/main/java/com/github/thedeathlycow/moregeodes/features/ModPlacedFeatures.java
@@ -9,11 +9,13 @@ import net.minecraft.world.gen.feature.PlacedFeature;
 public class ModPlacedFeatures {
 
     public static final RegistryKey<PlacedFeature> EMERALD_GEODE = of("emerald_geode");
+    public static final RegistryKey<PlacedFeature> EMERALD_GEODE_EXTRA = of("emerald_geode_extra");
     public static final RegistryKey<PlacedFeature> QUARTZ_GEODE = of("quartz_geode");
     public static final RegistryKey<PlacedFeature> DIAMOND_GEODE = of("diamond_geode");
     public static final RegistryKey<PlacedFeature> ECHO_GEODE = of("echo_geode");
 
     public static final RegistryKey<PlacedFeature> LAPIS_GEODE = of("lapis_geode");
+    public static final RegistryKey<PlacedFeature> LAPIS_GEODE_EXTRA = of("lapis_geode_extra");
     public static final RegistryKey<PlacedFeature> GYPSUM_PATCH = of("gypsum_patch");
     public static final RegistryKey<PlacedFeature> CERTUS_GEODE = of("certus_geode");
 

--- a/src/main/java/com/github/thedeathlycow/moregeodes/tag/ModBiomeTags.java
+++ b/src/main/java/com/github/thedeathlycow/moregeodes/tag/ModBiomeTags.java
@@ -9,10 +9,12 @@ import net.minecraft.world.biome.Biome;
 public class ModBiomeTags {
 
     public static final TagKey<Biome> HAS_EMERALD_GEODE = of("has_emerald_geode");
+    public static final TagKey<Biome> HAS_EXTRA_EMERALD_GEODES = of("has_extra_emerald_geodes");
     public static final TagKey<Biome> HAS_QUARTZ_GEODE = of("has_quartz_geode");
     public static final TagKey<Biome> HAS_DIAMOND_GEODE = of("has_diamond_geode");
     public static final TagKey<Biome> HAS_ECHO_GEODE = of("has_echo_geode");
     public static final TagKey<Biome> HAS_LAPIS_GEODE = of("has_lapis_geode");
+    public static final TagKey<Biome> HAS_EXTRA_LAPIS_GEODES = of("has_extra_lapis_geodes");
     public static final TagKey<Biome> HAS_GYPSUM_PATCH = of("has_gypsum_patch");
     public static final TagKey<Biome> HAS_CERTUS_GEODE = of("has_certus_geode");
 

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_certus_geode.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_certus_geode.json
@@ -1,8 +1,14 @@
 {
-  "replace": false,
-  "values": [
-    "#minecraft:is_overworld",
-    {"id": "#terralith:all_terralith_biomes", "required": false},
-    {"id": "#c:in_overworld", "required": false}
-  ]
+    "replace": false,
+    "values": [
+        "#minecraft:is_overworld",
+        {
+            "id": "#terralith:all_terralith_biomes",
+            "required": false
+        },
+        {
+            "id": "#c:in_overworld",
+            "required": false
+        }
+    ]
 }

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_diamond_geode.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_diamond_geode.json
@@ -1,8 +1,14 @@
 {
-  "replace": false,
-  "values": [
-    "#minecraft:is_overworld",
-    {"id": "#terralith:all_terralith_biomes", "required": false},
-    {"id": "#c:in_overworld", "required": false}
-  ]
+    "replace": false,
+    "values": [
+        "#minecraft:is_overworld",
+        {
+            "id": "#terralith:all_terralith_biomes",
+            "required": false
+        },
+        {
+            "id": "#c:in_overworld",
+            "required": false
+        }
+    ]
 }

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_echo_geode.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_echo_geode.json
@@ -1,6 +1,6 @@
 {
-  "replace": false,
-  "values": [
-    "minecraft:deep_dark"
-  ]
+    "replace": false,
+    "values": [
+        "minecraft:deep_dark"
+    ]
 }

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_emerald_geode.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_emerald_geode.json
@@ -1,19 +1,14 @@
 {
-  "replace": false,
-  "values": [
-    "#minecraft:is_mountain",
-    "#c:mountain",
-    "minecraft:grove",
-    {"id": "terralith:alpine_grove", "required": false},
-    {"id": "terralith:blooming_plateau", "required": false},
-    {"id": "terralith:emerald_peaks", "required": false},
-    {"id": "terralith:haze_mountain", "required": false},
-    {"id": "terralith:painted_mountains", "required": false},
-    {"id": "terralith:rocky_mountains", "required": false},
-    {"id": "terralith:stony_spires", "required": false},
-    {"id": "terralith:volcanic_crater", "required": false},
-    {"id": "terralith:volcanic_peaks", "required": false},
-    {"id": "terralith:windswept_spires", "required": false},
-    {"id": "#forge:is_mountain", "required": false}
-  ]
+    "replace": false,
+    "values": [
+        "#minecraft:is_overworld",
+        {
+            "id": "#terralith:all_terralith_biomes",
+            "required": false
+        },
+        {
+            "id": "#c:in_overworld",
+            "required": false
+        }
+    ]
 }

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_extra_emerald_geodes.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_extra_emerald_geodes.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:grove",
+        "#minecraft:is_mountain",
+        "#c:mountain"
+    ]
+}

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_extra_lapis_geodes.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_extra_lapis_geodes.json
@@ -2,12 +2,10 @@
     "replace": false,
     "values": [
         "minecraft:desert",
-        "#minecraft:is_badlands",
         "#c:desert",
         {
             "id": "#forge:is_desert",
             "required": false
-        },
-        "#c:badlands"
+        }
     ]
 }

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_gypsum_patch.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_gypsum_patch.json
@@ -1,10 +1,13 @@
 {
-	"replace": false,
-	"values": [
-		"minecraft:desert",
-		"#c:desert",
-		{ "id": "#forge:is_desert", "required": false },
-		"#minecraft:is_badlands",
-		"#c:badlands"
-	]
+    "replace": false,
+    "values": [
+        "minecraft:desert",
+        "#c:desert",
+        {
+            "id": "#forge:is_desert",
+            "required": false
+        },
+        "#minecraft:is_badlands",
+        "#c:badlands"
+    ]
 }

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_lapis_geode.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_lapis_geode.json
@@ -1,8 +1,11 @@
 {
-	"replace": false,
-	"values": [
-		"minecraft:desert",
-		"#c:desert",
-		{ "id": "#forge:is_desert", "required": false }
-	]
+    "replace": false,
+    "values": [
+        "minecraft:desert",
+        "#c:desert",
+        {
+            "id": "#forge:is_desert",
+            "required": false
+        }
+    ]
 }

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_lapis_geode.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_lapis_geode.json
@@ -1,10 +1,13 @@
 {
     "replace": false,
     "values": [
-        "minecraft:desert",
-        "#c:desert",
+        "#minecraft:is_overworld",
         {
-            "id": "#forge:is_desert",
+            "id": "#terralith:all_terralith_biomes",
+            "required": false
+        },
+        {
+            "id": "#c:in_overworld",
             "required": false
         }
     ]

--- a/src/main/resources/data/geodes/tags/worldgen/biome/has_quartz_geode.json
+++ b/src/main/resources/data/geodes/tags/worldgen/biome/has_quartz_geode.json
@@ -1,15 +1,39 @@
 {
-  "replace": false,
-  "values": [
-    "#minecraft:is_nether",
-    "#c:in_nether",
-    {"id": "incendium:ash_barrens", "required": false},
-    {"id": "incendium:infernal_dunes", "required": false},
-    {"id": "incendium:inverted_forest", "required": false},
-    {"id": "incendium:quartz_flats", "required": false},
-    {"id": "incendium:toxic_heap", "required": false},
-    {"id": "incendium:volcanic_deltas", "required": false},
-    {"id": "incendium:weeping_valley", "required": false},
-    {"id": "incendium:withered_forest", "required": false}
-  ]
+    "replace": false,
+    "values": [
+        "#minecraft:is_nether",
+        "#c:in_nether",
+        {
+            "id": "incendium:ash_barrens",
+            "required": false
+        },
+        {
+            "id": "incendium:infernal_dunes",
+            "required": false
+        },
+        {
+            "id": "incendium:inverted_forest",
+            "required": false
+        },
+        {
+            "id": "incendium:quartz_flats",
+            "required": false
+        },
+        {
+            "id": "incendium:toxic_heap",
+            "required": false
+        },
+        {
+            "id": "incendium:volcanic_deltas",
+            "required": false
+        },
+        {
+            "id": "incendium:weeping_valley",
+            "required": false
+        },
+        {
+            "id": "incendium:withered_forest",
+            "required": false
+        }
+    ]
 }

--- a/src/main/resources/data/geodes/worldgen/placed_feature/emerald_geode.json
+++ b/src/main/resources/data/geodes/worldgen/placed_feature/emerald_geode.json
@@ -3,7 +3,7 @@
 	"placement": [
 		{
 			"type": "minecraft:rarity_filter",
-			"chance": 24
+			"chance": 6
 		},
 		{
 			"type": "minecraft:in_square"
@@ -11,12 +11,12 @@
 		{
 			"type": "minecraft:height_range",
 			"height": {
-				"type": "minecraft:uniform",
+				"type": "minecraft:trapezoid",
 				"min_inclusive": {
-					"above_bottom": 6
+					"absolute": 32
 				},
 				"max_inclusive": {
-					"absolute": 64
+					"absolute": 480
 				}
 			}
 		},

--- a/src/main/resources/data/geodes/worldgen/placed_feature/emerald_geode_extra.json
+++ b/src/main/resources/data/geodes/worldgen/placed_feature/emerald_geode_extra.json
@@ -1,9 +1,9 @@
 {
-	"feature": "geodes:lapis_geode",
+	"feature": "geodes:emerald_geode",
 	"placement": [
 		{
 			"type": "minecraft:rarity_filter",
-			"chance": 64
+			"chance": 12
 		},
 		{
 			"type": "minecraft:in_square"
@@ -11,12 +11,12 @@
 		{
 			"type": "minecraft:height_range",
 			"height": {
-				"type": "minecraft:trapezoid",
+				"type": "minecraft:uniform",
 				"min_inclusive": {
-					"absolute": 0
+					"absolute": 64
 				},
 				"max_inclusive": {
-					"absolute": 64
+					"below_top": 0
 				}
 			}
 		},

--- a/src/main/resources/data/geodes/worldgen/placed_feature/lapis_geode_extra.json
+++ b/src/main/resources/data/geodes/worldgen/placed_feature/lapis_geode_extra.json
@@ -3,7 +3,7 @@
 	"placement": [
 		{
 			"type": "minecraft:rarity_filter",
-			"chance": 64
+			"chance": 12
 		},
 		{
 			"type": "minecraft:in_square"
@@ -11,12 +11,12 @@
 		{
 			"type": "minecraft:height_range",
 			"height": {
-				"type": "minecraft:trapezoid",
+				"type": "minecraft:uniform",
 				"min_inclusive": {
 					"absolute": 0
 				},
 				"max_inclusive": {
-					"absolute": 64
+					"absolute": 128
 				}
 			}
 		},


### PR DESCRIPTION
Revisits some geode placements. This is to allow the geodes to actually appear sometimes in heavily modded environments with lots of new cave biomes. In particular: 

- Emerald Geodes: Now generate in all Overworld biomes, but only at high elevations. 
- Lapis Lazuli Geodes: Generate in more warm biomes, not just deserts and badlands. 

Closes #44 